### PR TITLE
test: Playwright E2E 基盤 + CI + スモーク構成

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# chatwork_helper 環境変数のサンプル
+#
+# 通常の開発・E2E（モックページ）では環境変数は不要。
+# 実 Chatwork スモークテスト用の補助設定のみ記載する。
+#
+# このファイル（.env.example）はキー名のみをコミットする。
+# 実際の値は .env に書き、.env は .gitignore で除外済み。
+
+# Playwright を画面表示モードで動かす（任意・値があれば headed）
+# HEADED=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [master, v3]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run compile
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Unit tests (Vitest)
+        run: npm test
+
+      - name: Install Playwright (chromium)
+        run: npx playwright install --with-deps chromium
+
+      - name: Build extension
+        run: npm run build
+
+      - name: E2E tests (Playwright)
+        run: xvfb-run -a npx playwright test --project=e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # OS
 *.DS_Store
 
+# Claude Code (local)
+.claude/
+
 # Dependencies
 node_modules/
 

--- a/e2e/allread.spec.ts
+++ b/e2e/allread.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from './fixtures';
+
+const MOCK_URL = 'https://www.chatwork.com/';
+
+// gatewayRequests フィクスチャを beforeEach で受けて context.route を先に登録する
+test.beforeEach(async ({ page, gatewayRequests }) => {
+  void gatewayRequests;
+  await page.goto(MOCK_URL);
+  await page.waitForSelector('#_sideChatMoveMyChat');
+});
+
+test('全既読ボタンがルーム一覧上部に設置される', async ({ page }) => {
+  const button = page.locator('#_openedButton');
+  await expect(button).toBeVisible();
+  // マイチャットボタンの直後に挿入されている
+  await expect(page.locator('#_sideChatMoveMyChat + #_openedButton')).toHaveCount(1);
+});
+
+test('全既読ボタンのクリックで未読ルームのみ既読化 POST が飛ぶ', async ({
+  page,
+  gatewayRequests,
+}) => {
+  await page.locator('#_openedButton').click();
+
+  // 未読ルーム (rid=100, 300) の2件に POST が飛ぶのを待つ
+  await expect.poll(() => gatewayRequests.length).toBe(2);
+
+  const roomIds = gatewayRequests.map((r) => r.body.room_id).sort();
+  expect(roomIds).toEqual(['100', '300']);
+
+  // ACCESS_TOKEN（ページ変数）が _t として正しく載っている
+  for (const req of gatewayRequests) {
+    expect(req.body._t).toBe('mock-access-token');
+    expect(req.body.unread).toBe('0');
+    expect(req.url).toContain('myid=12345');
+  }
+
+  // DOM 上にメッセージがある rid=100 は last_chat_id を含む
+  const room100 = gatewayRequests.find((r) => r.body.room_id === '100');
+  expect(room100?.body.last_chat_id).toBe('m-3');
+});

--- a/e2e/chatwork.smoke.spec.ts
+++ b/e2e/chatwork.smoke.spec.ts
@@ -1,0 +1,57 @@
+import { test as base, chromium, expect, type BrowserContext } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EXTENSION_PATH = resolve(__dirname, '../.output/chrome-mv3');
+const AUTH_FILE = resolve(__dirname, '../playwright/.auth/chatwork.json');
+
+/**
+ * 実 Chatwork に対するスモークテスト（ローカル専用・CI 非対象）。
+ *
+ * 前提: 事前に `npm run smoke:auth` で認証情報を保存しておくこと。
+ * 方針: 破壊的操作（実際の既読化 POST）は一切行わず、UI 注入・ボタン表示・
+ *   ショートカットの非破壊系（タグ展開等）のみを検証する。
+ */
+const test = base.extend<{ context: BrowserContext }>({
+  context: async ({}, use) => {
+    const context = await chromium.launchPersistentContext('', {
+      channel: 'chromium',
+      headless: false,
+      args: [`--disable-extensions-except=${EXTENSION_PATH}`, `--load-extension=${EXTENSION_PATH}`],
+    });
+    // persistent context は storageState を直接受け取れないため cookie を手動投入する
+    if (existsSync(AUTH_FILE)) {
+      const state = JSON.parse(readFileSync(AUTH_FILE, 'utf-8')) as {
+        cookies?: Parameters<BrowserContext['addCookies']>[0];
+      };
+      if (state.cookies?.length) await context.addCookies(state.cookies);
+    }
+    await use(context);
+    await context.close();
+  },
+});
+
+test.skip(
+  !existsSync(AUTH_FILE),
+  '認証情報が未保存です。`npm run smoke:auth` を先に実行してください。',
+);
+
+test('実 Chatwork で全既読ボタンが UI に注入される', async ({ page }) => {
+  await page.goto('https://www.chatwork.com/');
+  // ルーム一覧の出現を待つ（DOM 構造変更検知のカナリアも兼ねる）
+  await page.waitForSelector('#_sideChatMoveMyChat', { timeout: 30_000 });
+  await expect(page.locator('#_openedButton')).toBeVisible({ timeout: 30_000 });
+});
+
+test('実 Chatwork で :info タグ展開が動作する（非破壊）', async ({ page }) => {
+  await page.goto('https://www.chatwork.com/');
+  await page.waitForSelector('#_chatText', { timeout: 30_000 });
+  await page.fill('#_chatText', ':info');
+  await page.focus('#_chatText');
+  await page.press('#_chatText', 'Enter');
+  await expect(page.locator('#_chatText')).toHaveValue('[info]\n[/info]');
+  // 送信しないようクリアしておく
+  await page.fill('#_chatText', '');
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,73 @@
+import { test as base, chromium, type BrowserContext, type Worker } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EXTENSION_PATH = resolve(__dirname, '../.output/chrome-mv3');
+const MOCK_HTML = readFileSync(resolve(__dirname, 'fixtures/chatwork-mock.html'), 'utf-8');
+
+/** gateway.php への既読化 POST を記録するための型 */
+export interface GatewayRequest {
+  url: string;
+  body: Record<string, string>;
+}
+
+interface Fixtures {
+  context: BrowserContext;
+  /** モック Chatwork を本物の URL で開いたページ + gateway 記録 */
+  gatewayRequests: GatewayRequest[];
+}
+
+/**
+ * Playwright で MV3 拡張をロードするフィクスチャ。
+ * - launchPersistentContext + --load-extension で拡張を読み込む
+ * - page.route で chatwork.com をモック HTML に差し替え（URL マッチで content script 発火）
+ * - gateway.php POST もモックし、リクエストボディを記録
+ */
+export const test = base.extend<Fixtures>({
+  context: async ({}, use) => {
+    const context = await chromium.launchPersistentContext('', {
+      channel: 'chromium',
+      headless: !process.env.HEADED,
+      args: [`--disable-extensions-except=${EXTENSION_PATH}`, `--load-extension=${EXTENSION_PATH}`],
+    });
+    await use(context);
+    await context.close();
+  },
+
+  gatewayRequests: async ({ context }, use) => {
+    const requests: GatewayRequest[] = [];
+
+    // gateway.php への既読化 POST をモック + 記録
+    await context.route('https://www.chatwork.com/gateway.php**', async (route) => {
+      const request = route.request();
+      const postData = request.postData() ?? '';
+      const body = Object.fromEntries(new URLSearchParams(postData));
+      requests.push({ url: request.url(), body });
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+
+    // それ以外の chatwork.com リクエストはモック HTML を本物の URL で配信
+    await context.route('https://www.chatwork.com/**', async (route) => {
+      if (route.request().url().includes('/gateway.php')) {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html; charset=utf-8',
+        body: MOCK_HTML,
+      });
+    });
+
+    await use(requests);
+  },
+});
+
+export const expect = test.expect;
+
+/** content script のロードを待つためのユーティリティ */
+export async function waitForServiceWorker(context: BrowserContext): Promise<Worker | undefined> {
+  return context.serviceWorkers()[0];
+}

--- a/e2e/fixtures/chatwork-mock.html
+++ b/e2e/fixtures/chatwork-mock.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>Chatwork Mock</title>
+    <!-- ページグローバル変数（MAIN world の page-bridge が読む対象） -->
+    <script>
+      window.MYID = '12345';
+      window.ACCESS_TOKEN = 'mock-access-token';
+      window.CLIENT_VER = '2.0';
+      window.LANGUAGE = 'ja';
+    </script>
+    <style>
+      body {
+        font-family: sans-serif;
+        margin: 0;
+        display: flex;
+      }
+      #roomList {
+        width: 240px;
+        border-right: 1px solid #ccc;
+      }
+      .roomListHeader {
+        display: flex;
+        padding: 8px;
+        gap: 8px;
+      }
+      .roomListItem {
+        list-style: none;
+        padding: 8px;
+      }
+      .roomListItem__roomName--unread {
+        font-weight: bold;
+      }
+      #main {
+        flex: 1;
+        padding: 16px;
+      }
+      ._message {
+        padding: 8px;
+        border-bottom: 1px solid #eee;
+      }
+      textarea {
+        width: 100%;
+        height: 80px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="roomList">
+      <div class="roomListHeader">
+        <div id="_sideChatMoveMyChat" role="button">マイチャット</div>
+        <!-- 全既読ボタンはここに注入される -->
+      </div>
+      <ul>
+        <li class="roomListItem" data-rid="100">
+          <p class="roomListItem__roomName--unread">未読ルームA</p>
+        </li>
+        <li class="roomListItem" data-rid="200">
+          <p class="roomListItem__roomName">既読ルームB</p>
+        </li>
+        <li class="roomListItem" data-rid="300">
+          <p class="roomListItem__roomName--unread">未読ルームC</p>
+        </li>
+      </ul>
+    </div>
+
+    <div id="main">
+      <div id="timeline">
+        <div class="_message chatTimeLineMessageMention" data-rid="100" data-mid="m-1">
+          自分宛てメンション
+        </div>
+        <div class="_message chatTimeLineMessageMine" data-rid="100" data-mid="m-2">
+          自分の送信メッセージ
+        </div>
+        <div class="_message" data-rid="100" data-mid="m-3">他人のメッセージ</div>
+      </div>
+
+      <div id="controls">
+        <button id="_to" type="button">TO</button>
+        <button id="_file" type="button">ファイル</button>
+        <button id="_inchargeEmpty" type="button">担当者</button>
+        <input id="_search" type="text" placeholder="検索" />
+      </div>
+
+      <h3>メッセージ入力</h3>
+      <textarea id="_chatText"></textarea>
+
+      <h3>タスク作成</h3>
+      <textarea id="_taskNameInput"></textarea>
+    </div>
+  </body>
+</html>

--- a/e2e/shortcuts.spec.ts
+++ b/e2e/shortcuts.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from './fixtures';
+import type { Page } from '@playwright/test';
+
+const MOCK_URL = 'https://www.chatwork.com/';
+
+/** チャット欄に値を入れて Enter を押す（content script が IME 非変換 Enter を検知する） */
+async function typeAndEnter(page: Page, selector: string, value: string) {
+  await page.fill(selector, value);
+  await page.focus(selector);
+  await page.press(selector, 'Enter');
+}
+
+test.beforeEach(async ({ page, gatewayRequests }) => {
+  void gatewayRequests; // route 登録を有効化
+  await page.goto(MOCK_URL);
+  await page.waitForSelector('#_chatText');
+  // content script の keydown リスナ登録を待つ
+  await page.waitForTimeout(300);
+});
+
+test('@@ → [toall] に置換される', async ({ page }) => {
+  await typeAndEnter(page, '#_chatText', '@@');
+  await expect(page.locator('#_chatText')).toHaveValue('[toall]');
+});
+
+test(':info → タグに展開される', async ({ page }) => {
+  await typeAndEnter(page, '#_chatText', ':info');
+  await expect(page.locator('#_chatText')).toHaveValue('[info]\n[/info]');
+});
+
+test(':title / :code → タグに展開される', async ({ page }) => {
+  await typeAndEnter(page, '#_chatText', ':title');
+  await expect(page.locator('#_chatText')).toHaveValue('[title]\n[/title]');
+
+  await typeAndEnter(page, '#_chatText', ':code');
+  await expect(page.locator('#_chatText')).toHaveValue('[code]\n[/code]');
+});
+
+test(':to → TO リストボタンがクリックされコマンドが消える', async ({ page }) => {
+  let clicked = false;
+  await page.exposeFunction('__markToClicked', () => {
+    clicked = true;
+  });
+  await page.evaluate(() => {
+    document.querySelector('#_to')?.addEventListener('click', () => {
+      (window as unknown as { __markToClicked: () => void }).__markToClicked();
+    });
+  });
+  await typeAndEnter(page, '#_chatText', ':to');
+  await expect(page.locator('#_chatText')).toHaveValue('');
+  expect(clicked).toBe(true);
+});
+
+test(':file → ファイルアップロードボタンがクリックされる', async ({ page }) => {
+  let clicked = false;
+  await page.exposeFunction('__markFileClicked', () => {
+    clicked = true;
+  });
+  await page.evaluate(() => {
+    document.querySelector('#_file')?.addEventListener('click', () => {
+      (window as unknown as { __markFileClicked: () => void }).__markFileClicked();
+    });
+  });
+  await typeAndEnter(page, '#_chatText', ':file');
+  await expect(page.locator('#_chatText')).toHaveValue('');
+  expect(clicked).toBe(true);
+});
+
+test(':f → 検索ボックスにフォーカスが移る', async ({ page }) => {
+  await typeAndEnter(page, '#_chatText', ':f');
+  await expect(page.locator('#_chatText')).toHaveValue('');
+  await expect(page.locator('#_search')).toBeFocused();
+});
+
+test(':me → 自分宛て TO のメッセージのみ表示される', async ({ page }) => {
+  await typeAndEnter(page, '#_chatText', ':me');
+  await expect(page.locator('[data-mid="m-1"]')).toBeVisible();
+  await expect(page.locator('[data-mid="m-2"]')).toBeHidden();
+  await expect(page.locator('[data-mid="m-3"]')).toBeHidden();
+});
+
+test(':mine → 自分の送信メッセージのみ表示される', async ({ page }) => {
+  await typeAndEnter(page, '#_chatText', ':mine');
+  await expect(page.locator('[data-mid="m-1"]')).toBeHidden();
+  await expect(page.locator('[data-mid="m-2"]')).toBeVisible();
+  await expect(page.locator('[data-mid="m-3"]')).toBeHidden();
+});
+
+test(':all → 全メッセージが再表示される', async ({ page }) => {
+  await typeAndEnter(page, '#_chatText', ':me');
+  await expect(page.locator('[data-mid="m-3"]')).toBeHidden();
+  await typeAndEnter(page, '#_chatText', ':all');
+  await expect(page.locator('[data-mid="m-1"]')).toBeVisible();
+  await expect(page.locator('[data-mid="m-2"]')).toBeVisible();
+  await expect(page.locator('[data-mid="m-3"]')).toBeVisible();
+});
+
+test(':task → 本文がタスク名入力欄へ移る', async ({ page }) => {
+  await typeAndEnter(page, '#_chatText', 'バグを直す\n:task');
+  await expect(page.locator('#_chatText')).toHaveValue('');
+  await expect(page.locator('#_taskNameInput')).toHaveValue('バグを直す\n');
+});
+
+test('タスク欄の :to → 担当者リストボタンがクリックされる', async ({ page }) => {
+  let clicked = false;
+  await page.exposeFunction('__markInchargeClicked', () => {
+    clicked = true;
+  });
+  await page.evaluate(() => {
+    document.querySelector('#_inchargeEmpty')?.addEventListener('click', () => {
+      (window as unknown as { __markInchargeClicked: () => void }).__markInchargeClicked();
+    });
+  });
+  await typeAndEnter(page, '#_taskNameInput', 'レビュー\n:to');
+  expect(clicked).toBe(true);
+  await expect(page.locator('#_taskNameInput')).toHaveValue('レビュー\n');
+});

--- a/e2e/smoke.setup.ts
+++ b/e2e/smoke.setup.ts
@@ -1,0 +1,41 @@
+import { chromium } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { mkdirSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const AUTH_DIR = resolve(__dirname, '../playwright/.auth');
+const AUTH_FILE = resolve(AUTH_DIR, 'chatwork.json');
+
+/**
+ * 実 Chatwork スモークテスト用の認証セットアップ（ローカル専用・CI 非対象）。
+ *
+ * 実行: `npm run smoke:auth`
+ * ブラウザが開くので手動でログイン → ルーム一覧が表示されたら Enter を押す。
+ * storageState が playwright/.auth/chatwork.json に保存される（.gitignore 済み）。
+ *
+ * セキュリティ: このファイルは認証 Cookie を保存する。公開リポジトリのため
+ * 保存先は必ず .gitignore に含めること。
+ */
+async function main() {
+  mkdirSync(AUTH_DIR, { recursive: true });
+
+  const browser = await chromium.launch({ channel: 'chromium', headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto('https://www.chatwork.com/login.php');
+  console.log('\n=== Chatwork に手動でログインしてください ===');
+  console.log('ルーム一覧が表示されたら、このターミナルで Enter を押してください。\n');
+
+  await new Promise<void>((resolve) => {
+    process.stdin.once('data', () => resolve());
+  });
+
+  await context.storageState({ path: AUTH_FILE });
+  console.log(`\n認証情報を保存しました: ${AUTH_FILE}`);
+  await browser.close();
+  process.exit(0);
+}
+
+void main();

--- a/entrypoints/helper.content.ts
+++ b/entrypoints/helper.content.ts
@@ -26,10 +26,17 @@ export default defineContentScript({
         const target = event.target;
         if (!(target instanceof HTMLElement)) return;
 
+        // コマンドが一致したら Enter のデフォルト動作（改行挿入・送信）を抑止する。
+        // 一致しない通常入力時は何もせず Chatwork 本来の挙動に委ねる。
+        let matched = false;
         if (target.matches(SELECTORS.chatText)) {
-          dispatchChatShortcuts(dom);
+          matched = dispatchChatShortcuts(dom);
         } else if (target.matches(SELECTORS.taskNameInput)) {
-          dispatchTaskShortcuts(dom);
+          matched = dispatchTaskShortcuts(dom);
+        }
+        if (matched) {
+          event.preventDefault();
+          event.stopPropagation();
         }
       },
       true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.0",
       "hasInstallScript": true,
       "devDependencies": {
+        "@playwright/test": "1.60.0",
         "eslint": "9.39.4",
         "eslint-config-prettier": "10.1.8",
         "happy-dom": "20.10.2",
@@ -1032,6 +1033,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -5518,6 +5535,53 @@
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,17 @@
     "compile": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "wxt build && playwright test --project=e2e",
+    "test:e2e:headed": "wxt build && HEADED=1 playwright test --project=e2e --headed",
+    "smoke:auth": "node e2e/smoke.setup.ts",
+    "smoke": "wxt build && playwright test --project=smoke",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "postinstall": "wxt prepare"
   },
   "devDependencies": {
+    "@playwright/test": "1.60.0",
     "eslint": "9.39.4",
     "eslint-config-prettier": "10.1.8",
     "happy-dom": "20.10.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  // 拡張のロードに persistent context を使うため並列実行は避ける
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
+  use: {
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'e2e',
+      testMatch: /.*\.spec\.ts/,
+      testIgnore: /.*\.smoke\.spec\.ts/,
+    },
+    {
+      name: 'smoke',
+      testMatch: /.*\.smoke\.spec\.ts/,
+    },
+  ],
+});

--- a/src/shortcuts/dispatcher.test.ts
+++ b/src/shortcuts/dispatcher.test.ts
@@ -41,15 +41,21 @@ describe('buildTriggerRegExp', () => {
 describe('dispatchChatShortcuts', () => {
   it('@@ → [toall] に置換してフォーカスする', () => {
     const f = fakeDom('@@');
-    dispatchChatShortcuts(f.dom);
+    expect(dispatchChatShortcuts(f.dom)).toBe(true);
     expect(f.chat()).toBe('[toall]');
     expect(f.calls).toContain('focusChatText');
   });
 
-  it('行中の @@ では発火しない', () => {
+  it('行中の @@ では発火しない（matched=false）', () => {
     const f = fakeDom('mail@@example.com');
-    dispatchChatShortcuts(f.dom);
+    expect(dispatchChatShortcuts(f.dom)).toBe(false);
     expect(f.chat()).toBe('mail@@example.com');
+    expect(f.calls).toHaveLength(0);
+  });
+
+  it('コマンドを含まない通常テキストは matched=false', () => {
+    const f = fakeDom('こんにちは');
+    expect(dispatchChatShortcuts(f.dom)).toBe(false);
     expect(f.calls).toHaveLength(0);
   });
 
@@ -128,14 +134,14 @@ describe('dispatchChatShortcuts', () => {
 describe('dispatchTaskShortcuts', () => {
   it('タスク入力欄の :to → 担当者リストを開いてコマンドを除去する', () => {
     const f = fakeDom('', 'レビュー依頼\n:to');
-    dispatchTaskShortcuts(f.dom);
+    expect(dispatchTaskShortcuts(f.dom)).toBe(true);
     expect(f.calls).toContain('openAssigneeList');
     expect(f.task()).toBe('レビュー依頼\n');
   });
 
-  it(':to を含まない場合は何もしない', () => {
+  it(':to を含まない場合は何もしない（matched=false）', () => {
     const f = fakeDom('', 'レビュー依頼');
-    dispatchTaskShortcuts(f.dom);
+    expect(dispatchTaskShortcuts(f.dom)).toBe(false);
     expect(f.calls).toHaveLength(0);
   });
 });

--- a/src/shortcuts/dispatcher.ts
+++ b/src/shortcuts/dispatcher.ts
@@ -10,11 +10,18 @@ export function buildTriggerRegExp(keySource: string): RegExp {
   return new RegExp(`(^|\n)${keySource}($|\n)`);
 }
 
-/** チャット入力欄での Enter 時に全ショートカット + タグ展開を判定・実行する */
-export function dispatchChatShortcuts(dom: ChatworkDom): void {
+/**
+ * チャット入力欄での Enter 時に全ショートカット + タグ展開を判定・実行する。
+ * @returns いずれかのコマンドが一致して実行されたか（呼び出し側が Enter の
+ *   デフォルト動作（改行挿入・メッセージ送信）を抑止するかの判断に使う）
+ */
+export function dispatchChatShortcuts(dom: ChatworkDom): boolean {
+  let matched = false;
+
   for (const shortcut of chatShortcuts) {
     if (buildTriggerRegExp(shortcut.key).test(dom.getChatText())) {
       shortcut.run(dom);
+      matched = true;
     }
   }
 
@@ -22,15 +29,24 @@ export function dispatchChatShortcuts(dom: ChatworkDom): void {
   for (const tag of EXPANDABLE_TAGS) {
     if (buildTriggerRegExp(`:${tag}`).test(dom.getChatText())) {
       dom.setChatText(expandTag(dom.getChatText(), tag));
+      matched = true;
     }
   }
+
+  return matched;
 }
 
-/** タスク名入力欄での Enter 時のショートカット判定・実行 */
-export function dispatchTaskShortcuts(dom: ChatworkDom): void {
+/**
+ * タスク名入力欄での Enter 時のショートカット判定・実行。
+ * @returns いずれかのコマンドが一致して実行されたか
+ */
+export function dispatchTaskShortcuts(dom: ChatworkDom): boolean {
+  let matched = false;
   for (const shortcut of taskShortcuts) {
     if (buildTriggerRegExp(shortcut.key).test(dom.getTaskText())) {
       shortcut.run(dom);
+      matched = true;
     }
   }
+  return matched;
 }


### PR DESCRIPTION
## 概要

v3 モダン化計画の Phase 3。全コマンドを E2E で動作確認できる基盤を構築する。

> **Note**: #42 (Phase 2 コアリライト) の上にスタック。#41 → #42 マージ後に base を `v3` に変更してマージする。

## E2E 方式（モックページ + 拡張ロード）

- `chromium.launchPersistentContext` + `--load-extension=.output/chrome-mv3` で MV3 拡張をロード
- `page.route('https://www.chatwork.com/**')` でモック HTML を**本物の URL のまま**配信 → content script の `matches` が通常どおり発火
- `gateway.php` への既読化 POST もモックし、リクエストボディ（`room_id` / `_t`=ACCESS_TOKEN / `last_chat_id`）をアサート

## カバレッジ

- **shortcuts.spec.ts**（11 ケース）: `@@` / `:info` / `:title` / `:code` / `:to` / `:file` / `:f` / `:me` / `:mine` / `:all` / `:task` / タスク欄 `:to`
- **allread.spec.ts**（2 ケース）: 全既読ボタンの設置 + 未読ルームのみ既読化 POST

→ **E2E 13 ケース green**（+ Vitest 42 件）

## 副次的なバグ修正

E2E で、Enter のデフォルト動作（textarea への改行挿入）でコマンド実行後に `\n` が混入することを発見。**コマンド一致時のみ `preventDefault`** する修正を dispatcher（`matched` を返す）+ helper に追加した。

## 実 Chatwork スモーク（ローカル専用・CI 非対象）

- `npm run smoke:auth` でブラウザを開いて手動ログイン → `playwright/.auth/chatwork.json`（gitignore 済）に storageState 保存
- `chatwork.smoke.spec.ts`: **破壊的操作は行わず** UI 注入・ボタン表示・タグ展開（非破壊系）のみ検証。実 DOM の構造変更を検知するカナリアも兼ねる
- 公開リポジトリ向け多層防御: `.env.example` のみコミット / 認証情報・`.env` は gitignore

## CI（GitHub Actions）

`.github/workflows/ci.yml`: `npm ci` → compile / lint / format / vitest → `playwright install chromium` → `wxt build` → `xvfb-run` で E2E → 失敗時レポートをアーティファクト保存。スモークは CI に含めない。

## Claude Code デバッグ

- `npm run test:e2e:headed` で実ブラウザ表示
- trace / screenshot / video を retain-on-failure → `npx playwright show-trace` で解析

🤖 Generated with [Claude Code](https://claude.com/claude-code)