### PR TITLE
fix: ショートカット実行後のカーソル位置を保持 (Closes #3)

### DIFF
--- a/e2e/shortcuts.spec.ts
+++ b/e2e/shortcuts.spec.ts
@@ -28,6 +28,16 @@ test(':info → タグに展開される', async ({ page }) => {
   await expect(page.locator('#_chatText')).toHaveValue('[info]\n[/info]');
 });
 
+test(':info 展開後にカーソルがタグの内側に来る（Issue #3）', async ({ page }) => {
+  await typeAndEnter(page, '#_chatText', ':info');
+  await expect(page.locator('#_chatText')).toHaveValue('[info]\n[/info]');
+  const selectionStart = await page.$eval(
+    '#_chatText',
+    (el) => (el as HTMLTextAreaElement).selectionStart,
+  );
+  expect(selectionStart).toBe('[info]\n'.length);
+});
+
 test(':title / :code → タグに展開される', async ({ page }) => {
   await typeAndEnter(page, '#_chatText', ':title');
   await expect(page.locator('#_chatText')).toHaveValue('[title]\n[/title]');

--- a/src/dom/chatworkDom.ts
+++ b/src/dom/chatworkDom.ts
@@ -12,9 +12,15 @@ export function createChatworkDom(doc: Document): ChatworkDom {
 
   return {
     getChatText: () => chatText()?.value ?? '',
-    setChatText(value: string) {
+    getChatCursor: () => chatText()?.selectionStart ?? 0,
+    setChatText(value: string, cursor?: number) {
       const el = chatText();
-      if (el) el.value = value;
+      if (!el) return;
+      el.value = value;
+      if (cursor !== undefined) {
+        const pos = Math.max(0, Math.min(cursor, value.length));
+        el.setSelectionRange(pos, pos);
+      }
     },
     focusChatText: () => chatText()?.focus(),
     getTaskText: () => taskInput()?.value ?? '',

--- a/src/shortcuts/cursor.test.ts
+++ b/src/shortcuts/cursor.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { expandTagWithCursor, stripCommandWithCursor, toallWithCursor } from './cursor';
+
+describe('toallWithCursor', () => {
+  it('@@ を [toall] に置換し、置換区間より後のカーソルをシフトする', () => {
+    // "@@ みんな" でカーソルが末尾(6)にある場合
+    const result = toallWithCursor('@@ みんな', 6);
+    expect(result.text).toBe('[toall] みんな');
+    // 2文字 → 7文字、差分 +5
+    expect(result.cursor).toBe(11);
+  });
+
+  it('置換区間より前のカーソルは動かさない', () => {
+    const result = toallWithCursor('x\n@@', 1);
+    expect(result.cursor).toBe(1);
+  });
+});
+
+describe('stripCommandWithCursor', () => {
+  it('コマンドを除去し、後続カーソルを詰める', () => {
+    // ":to\nhello" カーソルが末尾(9)
+    const result = stripCommandWithCursor(':to\nhello', ':to', 9);
+    expect(result.text).toBe('\nhello');
+    expect(result.cursor).toBe(6); // 9 - 3
+  });
+
+  it('コマンドより前のカーソルは保持する', () => {
+    const result = stripCommandWithCursor('ab\n:to', ':to', 2);
+    expect(result.cursor).toBe(2);
+  });
+
+  it('コマンドが無ければそのまま', () => {
+    const result = stripCommandWithCursor('hello', ':to', 3);
+    expect(result).toEqual({ text: 'hello', cursor: 3 });
+  });
+});
+
+describe('expandTagWithCursor', () => {
+  it('カーソルを開きタグと閉じタグの間に置く', () => {
+    const result = expandTagWithCursor(':info', 'info', 5);
+    expect(result.text).toBe('[info]\n[/info]');
+    // "[info]\n".length = 7
+    expect(result.cursor).toBe(7);
+  });
+
+  it('前置きテキストがあってもタグ内側を指す', () => {
+    const result = expandTagWithCursor('メモ\n:code', 'code', 8);
+    expect(result.text).toBe('メモ\n[code]\n[/code]');
+    // index("メモ\n":code) = 3, open "[code]\n".length = 7 → 10
+    expect(result.cursor).toBe(10);
+  });
+});

--- a/src/shortcuts/cursor.ts
+++ b/src/shortcuts/cursor.ts
@@ -1,0 +1,69 @@
+import { replaceToall } from './replaceToall';
+import type { ExpandableTag } from './expandTag';
+
+/** テキストとカーソル位置（selectionStart）のペア */
+export interface TextWithCursor {
+  text: string;
+  cursor: number;
+}
+
+/**
+ * テキストの一部を置換した際のカーソル位置を、置換区間との位置関係から補正する。
+ * - カーソルが置換区間より前: そのまま
+ * - 置換区間より後: 文字数の増減分だけシフト
+ * - 置換区間の内側: 置換後文字列の末尾へ寄せる
+ */
+function shiftCursor(
+  cursor: number,
+  matchIndex: number,
+  matchLength: number,
+  replacementLength: number,
+): number {
+  if (cursor <= matchIndex) return cursor;
+  if (cursor >= matchIndex + matchLength) {
+    return cursor + (replacementLength - matchLength);
+  }
+  return matchIndex + replacementLength;
+}
+
+/** `@@` → `[toall]` 置換（カーソル位置を保持） */
+export function toallWithCursor(text: string, cursor: number): TextWithCursor {
+  const match = /[@＠]{2}/.exec(text);
+  const newText = replaceToall(text);
+  if (!match) return { text: newText, cursor };
+  return {
+    text: newText,
+    cursor: shiftCursor(cursor, match.index, match[0].length, '[toall]'.length),
+  };
+}
+
+/** コマンド文字列（`:to` 等）の最初の出現を除去（カーソル位置を保持） */
+export function stripCommandWithCursor(
+  text: string,
+  command: string,
+  cursor: number,
+): TextWithCursor {
+  const index = text.indexOf(command);
+  if (index < 0) return { text, cursor };
+  const newText = text.slice(0, index) + text.slice(index + command.length);
+  return { text: newText, cursor: shiftCursor(cursor, index, command.length, 0) };
+}
+
+/**
+ * `:tag` → `[tag]\n[/tag]` 展開（カーソルは開きタグと閉じタグの間へ置く）。
+ * Issue #3: 展開直後にそのまま本文を打てるようにするため。
+ */
+export function expandTagWithCursor(
+  text: string,
+  tag: ExpandableTag,
+  cursor: number,
+): TextWithCursor {
+  const command = `:${tag}`;
+  const index = text.indexOf(command);
+  const open = `[${tag}]\n`;
+  const replacement = `${open}[/${tag}]`;
+  if (index < 0) return { text, cursor };
+  const newText = text.slice(0, index) + replacement + text.slice(index + command.length);
+  // カーソルは「[tag]\n」の直後（タグの内側）に固定する
+  return { text: newText, cursor: index + open.length };
+}

--- a/src/shortcuts/dispatcher.test.ts
+++ b/src/shortcuts/dispatcher.test.ts
@@ -3,14 +3,17 @@ import { buildTriggerRegExp, dispatchChatShortcuts, dispatchTaskShortcuts } from
 import type { ChatworkDom } from './types';
 
 /** 呼び出し履歴を記録するテスト用 ChatworkDom */
-function fakeDom(initialChat = '', initialTask = '') {
+function fakeDom(initialChat = '', initialTask = '', initialCursor = 0) {
   let chat = initialChat;
   let task = initialTask;
+  let cursor = initialCursor;
   const calls: string[] = [];
   const dom: ChatworkDom = {
     getChatText: () => chat,
-    setChatText: (v) => {
+    getChatCursor: () => cursor,
+    setChatText: (v, c) => {
       chat = v;
+      if (c !== undefined) cursor = c;
     },
     focusChatText: () => calls.push('focusChatText'),
     getTaskText: () => task,
@@ -24,7 +27,7 @@ function fakeDom(initialChat = '', initialTask = '') {
     focusSearch: () => calls.push('focusSearch'),
     filterMessages: (mode) => calls.push(`filter:${mode}`),
   };
-  return { dom, calls, chat: () => chat, task: () => task };
+  return { dom, calls, chat: () => chat, task: () => task, cursor: () => cursor };
 }
 
 describe('buildTriggerRegExp', () => {
@@ -112,6 +115,12 @@ describe('dispatchChatShortcuts', () => {
     const f = fakeDom('メモ\n:info');
     dispatchChatShortcuts(f.dom);
     expect(f.chat()).toBe('メモ\n[info]\n[/info]');
+  });
+
+  it(':info 展開時にカーソルがタグの内側に来る（Issue #3）', () => {
+    const f = fakeDom(':info', '', 5);
+    dispatchChatShortcuts(f.dom);
+    expect(f.cursor()).toBe('[info]\n'.length);
   });
 
   it(':title / :code → タグに展開する', () => {

--- a/src/shortcuts/dispatcher.ts
+++ b/src/shortcuts/dispatcher.ts
@@ -1,4 +1,5 @@
-import { EXPANDABLE_TAGS, expandTag } from './expandTag';
+import { expandTagWithCursor } from './cursor';
+import { EXPANDABLE_TAGS } from './expandTag';
 import { chatShortcuts, taskShortcuts } from './registry';
 import type { ChatworkDom } from './types';
 
@@ -25,10 +26,11 @@ export function dispatchChatShortcuts(dom: ChatworkDom): boolean {
     }
   }
 
-  // タグ展開: `:info` / `:title` / `:code` → `[tag]\n[/tag]`
+  // タグ展開: `:info` / `:title` / `:code` → `[tag]\n[/tag]`（カーソルはタグの内側へ）
   for (const tag of EXPANDABLE_TAGS) {
     if (buildTriggerRegExp(`:${tag}`).test(dom.getChatText())) {
-      dom.setChatText(expandTag(dom.getChatText(), tag));
+      const { text, cursor } = expandTagWithCursor(dom.getChatText(), tag, dom.getChatCursor());
+      dom.setChatText(text, cursor);
       matched = true;
     }
   }

--- a/src/shortcuts/registry.ts
+++ b/src/shortcuts/registry.ts
@@ -1,4 +1,4 @@
-import { replaceToall } from './replaceToall';
+import { stripCommandWithCursor, toallWithCursor } from './cursor';
 import { stripCommand } from './stripCommand';
 import { extractTaskName } from './moveToTask';
 import type { Shortcut } from './types';
@@ -12,7 +12,8 @@ export const chatShortcuts: Shortcut[] = [
     // 全員宛て [toall] の短縮形
     key: '[@＠]{2}',
     run(dom) {
-      dom.setChatText(replaceToall(dom.getChatText()));
+      const { text, cursor } = toallWithCursor(dom.getChatText(), dom.getChatCursor());
+      dom.setChatText(text, cursor);
       dom.focusChatText();
     },
   },
@@ -21,7 +22,12 @@ export const chatShortcuts: Shortcut[] = [
     key: ':to',
     run(dom) {
       dom.openToList();
-      dom.setChatText(stripCommand(dom.getChatText(), ':to'));
+      const { text, cursor } = stripCommandWithCursor(
+        dom.getChatText(),
+        ':to',
+        dom.getChatCursor(),
+      );
+      dom.setChatText(text, cursor);
     },
   },
   {
@@ -29,7 +35,12 @@ export const chatShortcuts: Shortcut[] = [
     key: ':file',
     run(dom) {
       dom.openFileUpload();
-      dom.setChatText(stripCommand(dom.getChatText(), ':file'));
+      const { text, cursor } = stripCommandWithCursor(
+        dom.getChatText(),
+        ':file',
+        dom.getChatCursor(),
+      );
+      dom.setChatText(text, cursor);
     },
   },
   {
@@ -37,7 +48,8 @@ export const chatShortcuts: Shortcut[] = [
     key: ':f',
     run(dom) {
       dom.focusSearch();
-      dom.setChatText(stripCommand(dom.getChatText(), ':f'));
+      const { text, cursor } = stripCommandWithCursor(dom.getChatText(), ':f', dom.getChatCursor());
+      dom.setChatText(text, cursor);
     },
   },
   {
@@ -45,7 +57,12 @@ export const chatShortcuts: Shortcut[] = [
     key: ':me',
     run(dom) {
       dom.filterMessages('me');
-      dom.setChatText(stripCommand(dom.getChatText(), ':me'));
+      const { text, cursor } = stripCommandWithCursor(
+        dom.getChatText(),
+        ':me',
+        dom.getChatCursor(),
+      );
+      dom.setChatText(text, cursor);
     },
   },
   {
@@ -53,7 +70,12 @@ export const chatShortcuts: Shortcut[] = [
     key: ':mine',
     run(dom) {
       dom.filterMessages('mine');
-      dom.setChatText(stripCommand(dom.getChatText(), ':mine'));
+      const { text, cursor } = stripCommandWithCursor(
+        dom.getChatText(),
+        ':mine',
+        dom.getChatCursor(),
+      );
+      dom.setChatText(text, cursor);
     },
   },
   {
@@ -61,7 +83,12 @@ export const chatShortcuts: Shortcut[] = [
     key: ':all',
     run(dom) {
       dom.filterMessages('all');
-      dom.setChatText(stripCommand(dom.getChatText(), ':all'));
+      const { text, cursor } = stripCommandWithCursor(
+        dom.getChatText(),
+        ':all',
+        dom.getChatCursor(),
+      );
+      dom.setChatText(text, cursor);
     },
   },
   {

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -7,7 +7,13 @@ export type FilterMode = 'me' | 'mine' | 'all';
  */
 export interface ChatworkDom {
   getChatText(): string;
-  setChatText(value: string): void;
+  /** チャット欄の現在のカーソル位置（selectionStart） */
+  getChatCursor(): number;
+  /**
+   * チャット欄のテキストを設定する。
+   * @param cursor 指定時は設定後にカーソル位置（selectionStart/End）を復元する（Issue #3）
+   */
+  setChatText(value: string, cursor?: number): void;
   focusChatText(): void;
   getTaskText(): string;
   setTaskText(value: string): void;


### PR DESCRIPTION
## 概要

Phase 5 / Issue #3。ショートカット実行後にカーソルがテキスト末尾へ飛んでしまう問題を修正する。

Closes #3

> **Note**: #44 の上にスタック。先行 PR マージ後に base を `v3` に変更する。

## 実装

- `ChatworkDom` に `getChatCursor()` と `setChatText(value, cursor?)` を追加。cursor 指定時は `setSelectionRange` で復元
- `src/shortcuts/cursor.ts` — 置換区間とカーソルの位置関係から新カーソルを算出する純粋関数
  - `toallWithCursor` — `@@` → `[toall]`
  - `stripCommandWithCursor` — コマンド除去（`:to` 等）
  - `expandTagWithCursor` — タグ展開。**カーソルを `[info]` と `[/info]` の間**に配置
- カーソル補正ルール: 置換区間より前は据え置き / 後ろは増減分シフト / 内側は置換後末尾へ

## 検証

- Vitest: cursor 8 件追加（計 50 件 green）
- E2E: `:info` 展開後の `selectionStart` がタグ内側を指すことをアサート（計 14 件 green）

🤖 Generated with [Claude Code](https://claude.com/claude-code)