### PR TITLE
feat: メッセージフィルタを CSS クラス方式に変更 + 解除バナー (Closes #4)

### DIFF
--- a/e2e/shortcuts.spec.ts
+++ b/e2e/shortcuts.spec.ts
@@ -105,6 +105,29 @@ test(':all → 全メッセージが再表示される', async ({ page }) => {
   await expect(page.locator('[data-mid="m-3"]')).toBeVisible();
 });
 
+test(':me フィルタ後に追加されたメッセージにも CSS が効く（Issue #4）', async ({ page }) => {
+  await typeAndEnter(page, '#_chatText', ':me');
+  // フィルタ適用後に新規メッセージを動的に追加
+  await page.evaluate(() => {
+    const msg = document.createElement('div');
+    msg.className = '_message';
+    msg.dataset.mid = 'm-late';
+    msg.textContent = '後から来た他人のメッセージ';
+    document.getElementById('timeline')?.appendChild(msg);
+  });
+  // 要素単位の操作なしでも CSS により隠れる
+  await expect(page.locator('[data-mid="m-late"]')).toBeHidden();
+});
+
+test('フィルタ中バナーの解除ボタンでフィルタが解除される（Issue #4）', async ({ page }) => {
+  await typeAndEnter(page, '#_chatText', ':me');
+  const banner = page.locator('#cwh-filter-banner');
+  await expect(banner).toBeVisible();
+  await banner.getByRole('button', { name: '解除' }).click();
+  await expect(banner).toHaveCount(0);
+  await expect(page.locator('[data-mid="m-3"]')).toBeVisible();
+});
+
 test(':task → 本文がタスク名入力欄へ移る', async ({ page }) => {
   await typeAndEnter(page, '#_chatText', 'バグを直す\n:task');
   await expect(page.locator('#_chatText')).toHaveValue('');

--- a/src/shortcuts/messageFilter.test.ts
+++ b/src/shortcuts/messageFilter.test.ts
@@ -1,7 +1,14 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { applyMessageFilter } from './messageFilter';
+import {
+  applyMessageFilter,
+  FILTER_BANNER_ID,
+  FILTER_CLASS,
+  FILTER_STYLE_ID,
+} from './messageFilter';
 
 function setupTimeline(): void {
+  document.head.innerHTML = '';
+  document.body.className = '';
   document.body.innerHTML = `
     <div class="_message chatTimeLineMessageMention" id="m1"></div>
     <div class="_message chatTimeLineMessageMine" id="m2"></div>
@@ -9,30 +16,60 @@ function setupTimeline(): void {
   `;
 }
 
-const display = (id: string) => (document.getElementById(id) as HTMLElement).style.display;
-
-describe('applyMessageFilter', () => {
+describe('applyMessageFilter (CSS クラス方式・Issue #4)', () => {
   beforeEach(setupTimeline);
 
-  it('me: 自分宛て TO のみ表示する', () => {
+  it('スタイルシートを一度だけ注入する', () => {
     applyMessageFilter(document, 'me');
-    expect(display('m1')).toBe('');
-    expect(display('m2')).toBe('none');
-    expect(display('m3')).toBe('none');
-  });
-
-  it('mine: 自分の送信のみ表示する', () => {
     applyMessageFilter(document, 'mine');
-    expect(display('m1')).toBe('none');
-    expect(display('m2')).toBe('');
-    expect(display('m3')).toBe('none');
+    expect(document.querySelectorAll(`#${FILTER_STYLE_ID}`)).toHaveLength(1);
   });
 
-  it('all: フィルタを解除して全表示する', () => {
+  it('me: body に me フィルタクラスを付与する', () => {
+    applyMessageFilter(document, 'me');
+    expect(document.body.classList.contains(FILTER_CLASS.me)).toBe(true);
+    expect(document.body.classList.contains(FILTER_CLASS.mine)).toBe(false);
+  });
+
+  it('mine: body に mine フィルタクラスを付与する', () => {
+    applyMessageFilter(document, 'mine');
+    expect(document.body.classList.contains(FILTER_CLASS.mine)).toBe(true);
+    expect(document.body.classList.contains(FILTER_CLASS.me)).toBe(false);
+  });
+
+  it('me → mine の切り替えでクラスが排他になる', () => {
+    applyMessageFilter(document, 'me');
+    applyMessageFilter(document, 'mine');
+    expect(document.body.classList.contains(FILTER_CLASS.me)).toBe(false);
+    expect(document.body.classList.contains(FILTER_CLASS.mine)).toBe(true);
+  });
+
+  it('all: 全フィルタクラスを除去する', () => {
     applyMessageFilter(document, 'me');
     applyMessageFilter(document, 'all');
-    expect(display('m1')).toBe('');
-    expect(display('m2')).toBe('');
-    expect(display('m3')).toBe('');
+    expect(document.body.classList.contains(FILTER_CLASS.me)).toBe(false);
+    expect(document.body.classList.contains(FILTER_CLASS.mine)).toBe(false);
+  });
+
+  it('フィルタ中はバナーを表示し、all で除去する', () => {
+    applyMessageFilter(document, 'me');
+    expect(document.getElementById(FILTER_BANNER_ID)).not.toBeNull();
+    applyMessageFilter(document, 'all');
+    expect(document.getElementById(FILTER_BANNER_ID)).toBeNull();
+  });
+
+  it('バナーの解除ボタンでフィルタが解除される', () => {
+    applyMessageFilter(document, 'me');
+    const button = document.querySelector<HTMLButtonElement>(`#${FILTER_BANNER_ID} button`);
+    expect(button).not.toBeNull();
+    button?.click();
+    expect(document.body.classList.contains(FILTER_CLASS.me)).toBe(false);
+    expect(document.getElementById(FILTER_BANNER_ID)).toBeNull();
+  });
+
+  it('バナーは重複しない', () => {
+    applyMessageFilter(document, 'me');
+    applyMessageFilter(document, 'mine');
+    expect(document.querySelectorAll(`#${FILTER_BANNER_ID}`)).toHaveLength(1);
   });
 });

--- a/src/shortcuts/messageFilter.ts
+++ b/src/shortcuts/messageFilter.ts
@@ -2,17 +2,102 @@ import { MESSAGE_CLASSES, SELECTORS } from '../dom/selectors';
 import type { FilterMode } from './types';
 
 /**
- * タイムラインのメッセージ表示フィルタ。
+ * メッセージ表示フィルタ（Issue #4）。
+ *
+ * 旧実装は各メッセージ要素の `style.display` を直接操作していたため、
+ * - 新規ロードされたメッセージにフィルタが効かない
+ * - Chatwork 側の再レンダリングと競合して再ロードが暴発する
+ * という問題があった。
+ *
+ * 本実装は body にフィルタ用クラスを付与し、注入したスタイルシートの
+ * `:not()` セレクタで非該当メッセージを隠す。これにより後から追加された
+ * メッセージにも自動でフィルタが適用され、要素単位の操作を行わない。
+ * 併せてフィルタ中であることを示すバナー + ワンクリック解除を表示する。
+ */
+export const FILTER_STYLE_ID = 'cwh-filter-style';
+export const FILTER_BANNER_ID = 'cwh-filter-banner';
+export const FILTER_CLASS: Record<Exclude<FilterMode, 'all'>, string> = {
+  me: 'cwh-filter-me',
+  mine: 'cwh-filter-mine',
+};
+
+const STYLE_TEXT = `
+.${FILTER_CLASS.me} ${SELECTORS.message}:not(.${MESSAGE_CLASSES.mention}),
+.${FILTER_CLASS.mine} ${SELECTORS.message}:not(.${MESSAGE_CLASSES.mine}) {
+  display: none !important;
+}
+#${FILTER_BANNER_ID} {
+  position: fixed;
+  top: 0;
+  right: 16px;
+  z-index: 2147483647;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: #f0ad4e;
+  color: #fff;
+  font-size: 12px;
+  border-radius: 0 0 6px 6px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+#${FILTER_BANNER_ID} button {
+  cursor: pointer;
+  border: 1px solid #fff;
+  background: transparent;
+  color: #fff;
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 12px;
+}
+`;
+
+const BANNER_LABEL: Record<Exclude<FilterMode, 'all'>, string> = {
+  me: '自分宛てのメッセージのみ表示中',
+  mine: '自分の送信のみ表示中',
+};
+
+/** フィルタ用スタイルシートを一度だけ注入する */
+export function ensureFilterStyle(doc: Document): void {
+  if (doc.getElementById(FILTER_STYLE_ID)) return;
+  const style = doc.createElement('style');
+  style.id = FILTER_STYLE_ID;
+  style.textContent = STYLE_TEXT;
+  (doc.head ?? doc.documentElement).appendChild(style);
+}
+
+/** フィルタ中バナーを更新する（mode='all' で除去） */
+function updateBanner(doc: Document, mode: FilterMode): void {
+  doc.getElementById(FILTER_BANNER_ID)?.remove();
+  if (mode === 'all') return;
+
+  const banner = doc.createElement('div');
+  banner.id = FILTER_BANNER_ID;
+
+  const label = doc.createElement('span');
+  label.textContent = BANNER_LABEL[mode];
+
+  const clearButton = doc.createElement('button');
+  clearButton.type = 'button';
+  clearButton.textContent = '解除';
+  clearButton.addEventListener('click', () => applyMessageFilter(doc, 'all'));
+
+  banner.append(label, clearButton);
+  doc.body.appendChild(banner);
+}
+
+/**
+ * メッセージ表示フィルタを適用する。
  * - me:   自分宛て TO/メンションのみ表示
  * - mine: 自分の送信メッセージのみ表示
- * - all:  すべて表示（フィルタ解除）
+ * - all:  フィルタ解除
  */
-export function applyMessageFilter(root: ParentNode, mode: FilterMode): void {
-  const messages = root.querySelectorAll<HTMLElement>(SELECTORS.message);
-  for (const message of messages) {
-    const visible =
-      mode === 'all' ||
-      message.classList.contains(mode === 'me' ? MESSAGE_CLASSES.mention : MESSAGE_CLASSES.mine);
-    message.style.display = visible ? '' : 'none';
+export function applyMessageFilter(doc: Document, mode: FilterMode): void {
+  ensureFilterStyle(doc);
+  const root = doc.body;
+  root.classList.remove(FILTER_CLASS.me, FILTER_CLASS.mine);
+  if (mode !== 'all') {
+    root.classList.add(FILTER_CLASS[mode]);
   }
+  updateBanner(doc, mode);
 }


### PR DESCRIPTION
## 概要

Phase 5 / Issue #4。`:me` / `:mine` のフィルタ実装をスマートにする。

Closes #4

> **Note**: #45 の上にスタック。先行 PR マージ後に base を `v3` に変更する。

## 問題（旧実装）

各メッセージ要素の `style.display` を直接操作していたため:
- 後からロードされたメッセージにフィルタが効かない
- Chatwork 側の再レンダリングと競合し再ロードが暴発する

## 実装

- **CSS クラス + スタイルシート注入方式**へ変更:
  - `body` に `cwh-filter-me` / `cwh-filter-mine` クラスを付与
  - 注入した `<style>` の `:not()` セレクタ（`display: none !important`）で非該当を非表示
  - → 後から追加されたメッセージにも自動適用、要素単位の操作なし
- **フィルタ中バナー**: 「自分宛てのみ表示中」等のインジケータ + ワンクリック「解除」ボタンを固定表示

## 検証

- Vitest: フィルタ 8 件に刷新（計 55 件 green）。クラス付与/排他/バナー表示・解除/スタイル単一注入を検証
- E2E: **フィルタ適用後に動的追加したメッセージが CSS で隠れる**こと、**バナー解除ボタン**で復帰することをアサート（計 16 件 green）

🤖 Generated with [Claude Code](https://claude.com/claude-code)