### PR TITLE
docs: README 刷新 + CLAUDE.md 作成 (Phase 6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+Chatwork 向け Chrome 拡張機能。[WXT](https://wxt.dev/)（TypeScript / Vite / Manifest V3）で構築。
+
+## コマンド
+
+| コマンド                          | 説明                                                                      |
+| --------------------------------- | ------------------------------------------------------------------------- |
+| `npm ci`                          | 依存インストール（lockfile 厳密再現。`npm install` ではなくこちらを使う） |
+| `npm run dev`                     | 開発用 Chrome を起動して拡張をホットリロード付きでロード                  |
+| `npm run build`                   | 本番ビルド（`.output/chrome-mv3/`）                                       |
+| `npm run zip`                     | Chrome Web Store 用 zip を生成                                            |
+| `npm run compile`                 | 型チェック（`tsc --noEmit`）                                              |
+| `npm run lint`                    | ESLint                                                                    |
+| `npm run format` / `format:check` | Prettier                                                                  |
+| `npm test`                        | Vitest 単体テスト（`src/**/*.test.ts`）                                   |
+| `npm run test:e2e`                | Playwright E2E（`wxt build` 後にモックページで実行）                      |
+| `npm run test:e2e:headed`         | ブラウザ表示つき E2E（`HEADED=1`）                                        |
+| `npm run smoke:auth`              | 実 Chatwork スモーク用に手動ログインして認証情報を保存                    |
+| `npm run smoke`                   | 実 Chatwork で非破壊系のみ検証（ローカル専用・CI 非対象）                 |
+
+## アーキテクチャ
+
+### content script 2 層構成
+
+- **`entrypoints/page-bridge.content.ts`**（`world: 'MAIN'`）: ページグローバル変数
+  `MYID` / `ACCESS_TOKEN` / `CLIENT_VER` / `LANGUAGE` を読み、CustomEvent（JSON 文字列）で
+  ISOLATED 側へ受け渡す。
+- **`entrypoints/helper.content.ts`**（ISOLATED）: ショートカット・全既読ボタン・お気に入り・
+  メンションサジェストの本体。MAIN とは `window.dispatchEvent` / `CustomEvent` で連携。
+
+### ロジック分離方針
+
+DOM 副作用とロジックを分離し、ロジックを純粋関数として Vitest でテストする。
+
+```
+src/
+├── shortcuts/   ショートカット（純粋関数）+ registry + dispatcher
+│                cursor.ts でカーソル位置を保持（Issue #3）
+│                messageFilter.ts は CSS クラス方式（Issue #4）
+├── allread/     未読走査 / 既読化 POST(fetch) / ボタン生成
+├── favorites/   お気に入り（chrome.storage.local）（Issue #5）
+├── suggest/     @ メンションサジェスト（Issue #2 PoC）
+├── bridge/      MAIN⇄ISOLATED の Promise ラッパ + イベント検証
+├── dom/         selectors.ts（セレクタ定数を一元管理）/ chatworkDom.ts
+└── types/       global.d.ts
+```
+
+### 重要な原則
+
+- **セレクタは `src/dom/selectors.ts` に集約**。Chatwork 側の DOM 変更時はここだけ直す。
+- **`innerHTML` を使わない**。UI は `createElement` 等の DOM API で構築する（XSS 対策）。
+- **`ACCESS_TOKEN` 等の秘密情報をログ出力しない**。保存もしない。
+- ショートカットは「テキスト in → テキスト out」の純粋関数にし、DOM 操作は
+  `ChatworkDom` インターフェース経由でディスパッチャが実行する。
+- 依存追加はバージョンを明示し、`package-lock.json` をコミットする。
+
+## テスト方針
+
+- **単体（Vitest）**: `src/` の純粋関数・ディスパッチャ・storage（`fakeBrowser`）。`happy-dom` 環境。
+- **E2E（Playwright）**: `.output/chrome-mv3` を `--load-extension` でロードし、`page.route` で
+  `chatwork.com` を本物の URL のままモック HTML（`e2e/fixtures/chatwork-mock.html`）に差し替える。
+  URL ベースで content script の `matches` が発火する。
+- **スモーク**: 実 Chatwork。認証情報（`playwright/.auth/`）は `.gitignore` 済み。CI 非対象。
+
+## CI
+
+`.github/workflows/ci.yml`: `npm ci` → compile / lint / format / vitest →
+`playwright install chromium` → `wxt build` → `xvfb-run` で E2E。スモークは含めない。
+
+## 既知の残課題
+
+- **Issue #2（メンションサジェスト）**: 実 Chatwork DOM のセレクタ・TO 記法の挙動を
+  スモートテストで検証する必要がある（`docs/issue-2-tolist-suggest-poc.md`）。
+- **npm audit**: `wxt` → `web-ext-run` の dev 依存に既知脆弱性が残るが、拡張成果物には
+  含まれない。上流の修正に追随する。

--- a/README.md
+++ b/README.md
@@ -1,55 +1,85 @@
-# Summary
+# chatwork helper
 
-Google Chrome Extention for Chatwork
+Chatwork を便利にする Google Chrome 拡張機能です。
 
-# Getting Started
+> **v3.0.0 より Manifest V3 + TypeScript（[WXT](https://wxt.dev/)）に全面リライトしました。**
+> Manifest V2 は Chrome で廃止済みのため、現行 Chrome で動作するよう刷新しています。
 
-Chrome ウェブストアに登録してあるのでご自身のブラウザに登録してください
+## インストール
+
+Chrome ウェブストア（v2 系）:
 https://chrome.google.com/webstore/detail/chatworkhelper/ddejlbfddlhkoaomiocpbjmpnjkbcnkj
 
-# Feature
+開発版を読み込む場合は [開発](#開発) を参照してください。
 
-- [All Feature](https://github.com/ryoichi-u/chatwork_helper/wiki/en_1.0-All-features)
-- [日本語版 全機能一覧](https://github.com/ryoichi-u/chatwork_helper/wiki/ja_1.0-%E6%A9%9F%E8%83%BD%E4%B8%80%E8%A6%A7)
+## 機能
 
-## Attaching `all read button` on top of room list
+### ショートカット（行頭で入力 + Enter）
 
-すべて既読ボタンがルーム一覧の上部に追加されます
+| ショートカット  | 機能                                                  | 備考                               |
+| --------------- | ----------------------------------------------------- | ---------------------------------- |
+| `@@ + enter`    | 全員宛て `[toall]` を挿入                             |                                    |
+| `:to + enter`   | TO リストを開く                                       | タスク作成欄では担当者リストを開く |
+| `:file + enter` | ファイルアップロードを開く                            |                                    |
+| `:f + enter`    | 検索窓へ移動                                          |                                    |
+| `:task + enter` | 入力中の本文をタスク名へ移す                          |                                    |
+| `:info + enter` | `[info][/info]` タグを挿入（`:title` / `:code` も可） | カーソルはタグの内側に入る (#3)    |
+| `:me + enter`   | 自分宛て TO のメッセージのみ表示                      | フィルタ中バナーから解除可能 (#4)  |
+| `:mine + enter` | 自分の送信メッセージのみ表示                          |                                    |
+| `:all + enter`  | フィルタ解除（全メッセージ表示）                      |                                    |
 
-| room list top                                                                                                                                                         |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [![https://gyazo.com/5925496f52e6e8a79fc13157d0252af2](https://i.gyazo.com/5925496f52e6e8a79fc13157d0252af2.gif)](https://gyazo.com/5925496f52e6e8a79fc13157d0252af2) |
+ショートカット実行後はカーソル位置が保持されます（Issue #3）。
 
-## Type shortcut key at beginning of line
+### 全既読ボタン
 
-以下のコマンドを段落の先頭で打つと様々な機能が利用できます
+ルーム一覧の上部に「すべて既読」ボタンを追加します。クリックで未読ルームをまとめて既読化します。
 
-| function                            | shortcut key    | comment                         |
-| ----------------------------------- | --------------- | ------------------------------- |
-| to all member as short tab          | `@@ + enter`    | http://goo.gl/ypKUnv            |
-| open toList                         | `:to + enter`   |
-| output tab easy (ex. [info][/info]) | `:info + enter` | can use :info, :code and :title |
-| jump to search                      | `:f + enter`    |
-| move message to task                | `:task + enter` |
-| open fileUpload                     | `:file + enter` |
-| only show message to you            | `:me + enter`   | http://goo.gl/tdJJhd            |
-| only show message from you          | `:mine + enter` |
-| show all message                    | `:all + enter`  |
+### お気に入り・あとで読む（Issue #5）
 
-| 内容                                     | ショートカット  | 備考                      |
-| ---------------------------------------- | --------------- | ------------------------- |
-| 全員toを短縮形で使えるようにする         | `@@ + enter`    | 要望 http://goo.gl/ypKUnv |
-| toListを開く                             | `:to + enter`   | 右側のタスク作成でもOK    |
-| 全て既読にするボタン付ける               | なし            | ルーム一覧の上にボタン    |
-| [info][/info]などのタグを簡単に作る      | `:info + enter` | info, code, titleに対応   |
-| 検索窓に移る                             | `:f + enter`    |
-| メッセージに書いていた文字をタスクに移す | `:task + enter` |
-| fileUploadを開ける                       | `:file + enter` |
-| 自分へのto以外は隠す                     | `:me + enter`   | 要望 http://goo.gl/tdJJhd |
-| 自分の送信以外は隠す                     | `:mine + enter` |
-| 隠したメッセージを戻す                   | `:all + enter`  |
+- メッセージにマウスを乗せると「★ あとで読む」ボタンが表示され、クリックで保存できます。
+- ルーム一覧ヘッダの ★ ボタンで保存一覧パネルを開き、クリックで該当メッセージへジャンプ／削除できます。
+- 保存は `chrome.storage.local` に永続化されます（サーバー不要）。
 
-# How to Development
+### @ メンションサジェスト（Issue #2・PoC）
 
-- [English](https://github.com/ryoichi-u/chatwork_helper/wiki/en_2.0-How-to-development)
-- [日本語版](https://github.com/ryoichi-u/chatwork_helper/wiki/js_2.0-%E9%96%8B%E7%99%BA%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
+`@` を入力するとルームメンバーのサジェストが表示され、選択すると TO タグが挿入されます。
+※実 Chatwork DOM での検証が残課題です（`docs/issue-2-tolist-suggest-poc.md` 参照）。
+
+## アーキテクチャ
+
+[WXT](https://wxt.dev/)（TypeScript / Vite / Manifest V3）で構築。content script は 2 層構成です。
+
+| entrypoint                           | world    | 役割                                                                  |
+| ------------------------------------ | -------- | --------------------------------------------------------------------- |
+| `entrypoints/page-bridge.content.ts` | MAIN     | ページ変数（`MYID` / `ACCESS_TOKEN` 等）を読み CustomEvent で受け渡し |
+| `entrypoints/helper.content.ts`      | ISOLATED | ショートカット・全既読・お気に入り・サジェストの本体                  |
+
+ロジックは `src/` 配下の純粋関数に分離し、DOM 副作用は薄いインターフェース経由で実行することで Vitest によるテストを可能にしています。詳細は [CLAUDE.md](./CLAUDE.md) を参照。
+
+## 開発
+
+```bash
+npm ci              # 依存インストール（lockfile 厳密再現）
+npm run dev         # 開発用に Chrome を起動して拡張をロード
+npm run build       # 本番ビルド（.output/chrome-mv3）
+npm run zip         # Chrome Web Store 用 zip を生成
+```
+
+### テスト
+
+```bash
+npm test            # Vitest（純粋ロジックの単体テスト）
+npm run test:e2e    # Playwright E2E（モックページ + 拡張ロード）
+npm run test:e2e:headed  # ブラウザ表示つき E2E
+```
+
+E2E は `page.route` で Chatwork のページを本物の URL のままモック HTML に差し替えてテストします。
+
+### 実 Chatwork スモークテスト（ローカル専用）
+
+```bash
+npm run smoke:auth  # ブラウザでログイン → 認証情報を保存（.gitignore 済み）
+npm run smoke       # 実 Chatwork で非破壊系のみ検証
+```
+
+詳細なビルド・テストコマンドは [CLAUDE.md](./CLAUDE.md) を参照してください。


### PR DESCRIPTION
## 概要

v3 モダン化計画の Phase 6（リリース準備）。

> **Note**: #48 の上にスタック。スタックチェーンの最終 PR。

## 変更内容

- **README** を v3（MV3 / WXT / TypeScript）の内容に全面更新
  - 全機能（ショートカット / 全既読 / お気に入り / メンションサジェスト）
  - 2 層 content script アーキテクチャ
  - 開発・テスト・スモークの手順
- **CLAUDE.md** を新規作成（コマンド一覧・アーキテクチャ・テスト方針・コーディング原則）

## リリース成果物

- バージョン **3.0.0**
- `npm run zip` → `.output/chatwork-helper-3.0.0-chrome.zip` を生成（Chrome Web Store 用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)